### PR TITLE
Report unit test coverage to codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,11 @@ jobs:
       with:
         go-version: 1.14.x
     - name: Test
-      run: go test ./...
+      run: go test ./... -coverprofile cover.out
+    - name: Report coverage
+      run: bash <(curl -s https://codecov.io/bash)
+      env:
+        CODECOV_TOKEN: a99a7ac2-ad9e-4c7a-b33a-17732e3469f4
 
   stage:
     needs: test

--- a/pkg/reconciler/provisionedservice/controller_test.go
+++ b/pkg/reconciler/provisionedservice/controller_test.go
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package provisionedservice
+
+import (
+	"testing"
+)
+
+func TestStub(t *testing.T) {
+	// TODO add tests
+}

--- a/pkg/reconciler/servicebinding/controller_test.go
+++ b/pkg/reconciler/servicebinding/controller_test.go
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package servicebinding
+
+import (
+	"testing"
+)
+
+func TestStub(t *testing.T) {
+	// TODO add tests
+}

--- a/pkg/reconciler/servicebindingprep/controller_test.go
+++ b/pkg/reconciler/servicebindingprep/controller_test.go
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package servicebindingprep
+
+import (
+	"testing"
+)
+
+func TestStub(t *testing.T) {
+	// TODO add tests
+}

--- a/pkg/reconciler/servicebindingprep/resources/secret_test.go
+++ b/pkg/reconciler/servicebindingprep/resources/secret_test.go
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resources
+
+import (
+	"testing"
+)
+
+func TestStub(t *testing.T) {
+	// TODO add tests
+}

--- a/pkg/resolver/serviceable_resolver_test.go
+++ b/pkg/resolver/serviceable_resolver_test.go
@@ -1,0 +1,14 @@
+/*
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package resolver
+
+import (
+	"testing"
+)
+
+func TestStub(t *testing.T) {
+	// TODO add tests
+}


### PR DESCRIPTION
Add stub tests to packages that should have tests, but don't so that
they are reported with 0% coverage.

Resolves #17 