### PR TITLE
Implement Custom Projections extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,13 @@ ko apply --strict -f config
 Samples are located in the [samples directory](./samples), including:
 
 - [Spring PetClinic with MySQL](./samples/petclinic)
+- [Custom Projections](./samples/custom-projections)
 
 ## Resources
 
 ### ServiceBinding (service.binding/v1alpha2)
 
-The `ServiceBinding` resource shape and behavior is defined upstream. In addition to the [core specification](https://github.com/k8s-service-bindings/spec#service-binding), the [Role-Based Access Control (RBAC) extension](https://github.com/k8s-service-bindings/spec#role-based-access-control-rbac) is also supported by this implementation.
+The `ServiceBinding` resource shape and behavior is defined upstream. In addition to the [core specification](https://github.com/k8s-service-bindings/spec#service-binding), the [Custom Projects](https://github.com/k8s-service-bindings/spec/blob/master/README.md#custom-projection) and [Role-Based Access Control (RBAC)](https://github.com/k8s-service-bindings/spec#role-based-access-control-rbac) extensions are also supported by this implementation.
 
 ```
 apiVersion: service.binding/v1alpha2

--- a/pkg/reconciler/servicebinding/resources/servicebindingprojection.go
+++ b/pkg/reconciler/servicebinding/resources/servicebindingprojection.go
@@ -6,6 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package resources
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/kmeta"
 
@@ -17,8 +19,9 @@ import (
 func MakeServiceBindingProjection(binding *servicebindingv1alpha2.ServiceBinding) (*servicebindinginternalv1alpha2.ServiceBindingProjection, error) {
 	projection := &servicebindinginternalv1alpha2.ServiceBindingProjection{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourcenames.ServiceBindingProjection(binding),
-			Namespace: binding.Namespace,
+			Name:        resourcenames.ServiceBindingProjection(binding),
+			Namespace:   binding.Namespace,
+			Annotations: map[string]string{},
 			Labels: kmeta.UnionMaps(binding.GetLabels(), map[string]string{
 				servicebindingv1alpha2.ServiceBindingLabelKey: binding.Name,
 			}),
@@ -30,6 +33,13 @@ func MakeServiceBindingProjection(binding *servicebindingv1alpha2.ServiceBinding
 			Application: *binding.Spec.Application,
 			Env:         binding.Spec.Env,
 		},
+	}
+
+	for k, v := range binding.Annotations {
+		// copy forward "serice.bindings" annotations
+		if strings.Contains(k, servicebindingv1alpha2.GroupName) {
+			projection.Annotations[k] = v
+		}
 	}
 
 	return projection, nil

--- a/pkg/reconciler/servicebinding/resources/servicebindingprojection_test.go
+++ b/pkg/reconciler/servicebinding/resources/servicebindingprojection_test.go
@@ -30,6 +30,11 @@ func TestMakeServiceBindingProjection(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "my-namespace",
 					Name:      "my-binding",
+					Annotations: map[string]string{
+						"projection.service.bindings/type": "Custom",
+						"service.bindings/include":         "me",
+						"ignore":                           "me",
+					},
 				},
 				Spec: servicebindingv1alpha2.ServiceBindingSpec{
 					Name: "my-binding",
@@ -57,6 +62,10 @@ func TestMakeServiceBindingProjection(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "my-namespace",
 					Name:      "my-binding",
+					Annotations: map[string]string{
+						"projection.service.bindings/type": "Custom",
+						"service.bindings/include":         "me",
+					},
 					Labels: map[string]string{
 						"service.binding/servicebinding": "my-binding",
 					},

--- a/pkg/reconciler/servicebindingprojection/servicebindingprojection.go
+++ b/pkg/reconciler/servicebindingprojection/servicebindingprojection.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 VMware, Inc.
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package servicebindingprojection
+
+import (
+	"context"
+
+	servicebindinginternalv1alpha2listers "github.com/vmware-labs/service-bindings/pkg/client/listers/servicebindinginternal/v1alpha2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/cache"
+	"knative.dev/pkg/controller"
+	"knative.dev/pkg/logging"
+	"knative.dev/pkg/reconciler"
+	"knative.dev/pkg/webhook/psbinding"
+)
+
+var (
+	_ controller.Reconciler  = (*ConditionalReconciler)(nil)
+	_ reconciler.LeaderAware = (*ConditionalReconciler)(nil)
+)
+
+type delegateReconciler interface {
+	controller.Reconciler
+	reconciler.LeaderAware
+}
+
+type ConditionalReconciler struct {
+	Delegate *psbinding.BaseReconciler
+	Lister   servicebindinginternalv1alpha2listers.ServiceBindingProjectionLister
+}
+
+func (r *ConditionalReconciler) Reconcile(ctx context.Context, key string) error {
+	logger := logging.FromContext(ctx)
+
+	// convert the namespace/name string into a distinct namespace and name
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		logger.Errorf("invalid resource key: %s", key)
+		return nil
+	}
+
+	// ignore resources we are not a leader for
+	if !r.Delegate.IsLeaderFor(types.NamespacedName{Namespace: namespace, Name: name}) {
+		return nil
+	}
+
+	// get the resource with this namespace/name.
+	original, err := r.Lister.ServiceBindingProjections(namespace).Get(name)
+
+	if errors.IsNotFound(err) {
+		// the resource may no longer exist, in which case we stop processing.
+		logger.Debugf("resource %q no longer exists", key)
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	// don't modify the informers copy.
+	resource := original.DeepCopy()
+
+	isCustomProjection := resource.IsCustomProjection()
+	hasOurFinalizer := sets.NewString(resource.GetFinalizers()...).Has(r.Delegate.GVR.GroupResource().String())
+	if isCustomProjection && !hasOurFinalizer {
+		// a third-party reconciler is responsible for this resource
+		logger.Debugf("skipping reconciliation for %q, custom projection", key)
+		return nil
+	}
+
+	// continue with our projection
+	err = r.Delegate.Reconcile(ctx, key)
+	if err != nil {
+		return err
+	}
+
+	if isCustomProjection {
+		// remove our finalizer since we are no longer responsible for this resource
+		return r.Delegate.RemoveFinalizer(ctx, resource)
+	}
+
+	return nil
+}
+
+func (r *ConditionalReconciler) Promote(b reconciler.Bucket, enq func(reconciler.Bucket, types.NamespacedName)) error {
+	return r.Delegate.Promote(b, enq)
+}
+
+func (r *ConditionalReconciler) Demote(b reconciler.Bucket) {
+	r.Delegate.Demote(b)
+}

--- a/pkg/reconciler/servicebindingprojection/servicebindingprojection_test.go
+++ b/pkg/reconciler/servicebindingprojection/servicebindingprojection_test.go
@@ -6,9 +6,26 @@ SPDX-License-Identifier: Apache-2.0
 package servicebindingprojection
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	servicebindinginternalv1alpha2 "github.com/vmware-labs/service-bindings/pkg/apis/servicebindinginternal/v1alpha2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	clientgotesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/record"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+	"knative.dev/pkg/client/injection/ducks/duck/v1/podspecable"
 	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	dynamicclient "knative.dev/pkg/injection/clients/dynamicclient"
+	"knative.dev/pkg/tracker"
+	"knative.dev/pkg/webhook/psbinding"
 
 	// register injection fakes
 	_ "github.com/vmware-labs/service-bindings/pkg/client/injection/informers/servicebindinginternal/v1alpha2/servicebindingprojection/fake"
@@ -16,6 +33,7 @@ import (
 	_ "knative.dev/pkg/client/injection/kube/informers/core/v1/namespace/fake"
 	_ "knative.dev/pkg/injection/clients/dynamicclient/fake"
 
+	. "github.com/vmware-labs/service-bindings/pkg/reconciler/testing"
 	. "knative.dev/pkg/reconciler/testing"
 )
 
@@ -27,4 +45,227 @@ func TestNewController(t *testing.T) {
 	if c == nil {
 		t.Fatal("expected NewController to return a non-nil value")
 	}
+}
+
+func TestReconcile(t *testing.T) {
+	namespace := "my-namespace"
+	name := "my-service"
+	key := fmt.Sprintf("%s/%s", namespace, name)
+
+	table := TableTest{{
+		Name: "bad workqueue key",
+		Key:  "too/many/parts",
+	}, {
+		Name: "key not found",
+		Key:  key,
+	}, {
+		Name: "nop - in sync",
+		Key:  key,
+		Objects: []runtime.Object{
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					Labels: map[string]string{
+						"bindings.knative.dev/include": "true",
+					},
+				},
+			},
+			&servicebindinginternalv1alpha2.ServiceBindingProjection{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					Finalizers: []string{
+						"servicebindingprojections.internal.service.binding",
+					},
+					Generation: 1,
+				},
+				Spec: servicebindinginternalv1alpha2.ServiceBindingProjectionSpec{
+					Name: name,
+					Application: servicebindinginternalv1alpha2.ApplicationReference{
+						Reference: tracker.Reference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "my-application",
+						},
+					},
+					Binding: corev1.LocalObjectReference{
+						Name: "my-secret",
+					},
+				},
+				Status: servicebindinginternalv1alpha2.ServiceBindingProjectionStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 1,
+						Conditions: duckv1.Conditions{
+							{
+								Type:   servicebindinginternalv1alpha2.ServiceBindingProjectionConditionApplicationAvailable,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   servicebindinginternalv1alpha2.ServiceBindingProjectionConditionReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "my-application",
+					Annotations: map[string]string{
+						"internal.service.binding/service-binding-projection-my-service": "my-secret-binding",
+					},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Volumes: []corev1.Volume{
+								{
+									Name: "my-secret-binding",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "my-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, {
+		Name: "nop - ignore custom projections",
+		Key:  key,
+		Objects: []runtime.Object{
+			&servicebindinginternalv1alpha2.ServiceBindingProjection{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					Annotations: map[string]string{
+						"projection.service.binding/type": "Custom",
+					},
+					Generation: 1,
+				},
+				Spec: servicebindinginternalv1alpha2.ServiceBindingProjectionSpec{
+					Name: name,
+					Application: servicebindinginternalv1alpha2.ApplicationReference{
+						Reference: tracker.Reference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "my-application",
+						},
+					},
+					Binding: corev1.LocalObjectReference{
+						Name: "my-secret",
+					},
+				},
+			},
+		},
+	}, {
+		Name: "undo previous binding that is now custom",
+		Key:  key,
+		Objects: []runtime.Object{
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					Labels: map[string]string{
+						"bindings.knative.dev/include": "true",
+					},
+				},
+			},
+			&servicebindinginternalv1alpha2.ServiceBindingProjection{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					Annotations: map[string]string{
+						"projection.service.binding/type": "Custom",
+					},
+					Finalizers: []string{
+						"servicebindingprojections.internal.service.binding",
+					},
+					Generation: 1,
+				},
+				Spec: servicebindinginternalv1alpha2.ServiceBindingProjectionSpec{
+					Name: name,
+					Application: servicebindinginternalv1alpha2.ApplicationReference{
+						Reference: tracker.Reference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "my-application",
+						},
+					},
+					Binding: corev1.LocalObjectReference{
+						Name: "my-secret",
+					},
+				},
+				Status: servicebindinginternalv1alpha2.ServiceBindingProjectionStatus{
+					Status: duckv1.Status{
+						ObservedGeneration: 1,
+						Conditions: duckv1.Conditions{
+							{
+								Type:   servicebindinginternalv1alpha2.ServiceBindingProjectionConditionApplicationAvailable,
+								Status: corev1.ConditionTrue,
+							},
+							{
+								Type:   servicebindinginternalv1alpha2.ServiceBindingProjectionConditionReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+			&appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      "my-application",
+					Annotations: map[string]string{
+						"internal.service.binding/service-binding-projection-my-service": "my-secret-binding",
+					},
+				},
+				// will also remove injected PodTemplateSpec items, but the
+				// patch bytes are not ordered deterministically so we're
+				// artificially limiting the patch to a single item.
+			},
+		},
+		WantPatches: []clientgotesting.PatchActionImpl{
+			{
+				ActionImpl: clientgotesting.ActionImpl{
+					Namespace: namespace,
+				},
+				Name:      "my-application",
+				PatchType: types.JSONPatchType,
+				Patch:     []byte(`[{"op":"remove","path":"/metadata/annotations"}]`),
+			},
+			{
+				ActionImpl: clientgotesting.ActionImpl{
+					Namespace: namespace,
+				},
+				Name:      name,
+				PatchType: types.MergePatchType,
+				Patch:     []byte(`{"metadata":{"finalizers":[],"resourceVersion":""}}`),
+			},
+		},
+	}}
+
+	table.Test(t, MakeFactory(func(ctx context.Context, listers *Listers, cmw configmap.Watcher) controller.Reconciler {
+		ctx = podspecable.WithDuck(ctx)
+
+		c := &ConditionalReconciler{
+			Delegate: &psbinding.BaseReconciler{
+				GVR: servicebindinginternalv1alpha2.SchemeGroupVersion.WithResource("servicebindingprojections"),
+				Get: func(namespace string, name string) (psbinding.Bindable, error) {
+					return listers.GetServiceBindingProjectionLister().ServiceBindingProjections(namespace).Get(name)
+				},
+				DynamicClient: dynamicclient.Get(ctx),
+				Recorder: record.NewBroadcaster().NewRecorder(
+					scheme.Scheme, corev1.EventSource{Component: controllerAgentName}),
+				NamespaceLister: listers.GetNamespaceLister(),
+				Tracker:         GetTracker(ctx),
+				Factory:         podspecable.Get(ctx),
+			},
+			Lister: listers.GetServiceBindingProjectionLister(),
+		}
+		return c
+	}))
 }

--- a/pkg/reconciler/testing/listers.go
+++ b/pkg/reconciler/testing/listers.go
@@ -70,6 +70,10 @@ func (l *Listers) GetServiceBindingsObjects() []runtime.Object {
 	return l.sorter.ObjectsForSchemeFunc(fakeservicebindingsclientset.AddToScheme)
 }
 
+func (l *Listers) GetNamespaceLister() corev1listers.NamespaceLister {
+	return corev1listers.NewNamespaceLister(l.IndexerFor(&corev1.Namespace{}))
+}
+
 func (l *Listers) GetSecretLister() corev1listers.SecretLister {
 	return corev1listers.NewSecretLister(l.IndexerFor(&corev1.Secret{}))
 }

--- a/samples/custom-projection/README.md
+++ b/samples/custom-projection/README.md
@@ -1,0 +1,75 @@
+# Custom Projection
+
+[Custom Projections][custom-projections] are an extension to the Service Bindings spec that allows another controller to manage how the binding is applied to the application.
+Service binding implementation are not required to support custom projections, so this behavior may not be portable to other implementations.
+By default, PodSpecable resources (`Deployment`, `Job`, Knative `Service`, etc) are the only type of resource that the application can reference.
+
+To mark a resource as custom, the `ServiceBinding` resource **MUST** set the `projection.service.binding/type: Custom` annotation.
+
+## Setup
+
+If not already installed, [install the ServiceBinding CRD and controller][install].
+
+## Deploy
+
+Apply the custom application, service and connect them with a ServiceBinding:
+
+```sh
+kubectl apply -f ./samples/custom-projection
+```
+
+## Understand
+
+It may appear that not much happened.
+The normal ServiceBinding reconciler will lookup the service secret, apply mappings to the secret and then project the binding into the application.
+With a custom projection, the `ServiceBinding` will not project into the application.
+Instead of managing the projection itself, a new resource `ServiceBindingProjection` is created.
+It is the responsibility of a third-party reconciler in the cluster to reconcile the `ServiceBindingProjection`, the `ServiceBinding` controller is now hands-off for this binding.
+
+```sh
+kubectl describe servicebindingprojections.internal.service.binding custom
+```
+
+```
+Name:         custom
+Namespace:    default
+Labels:       service.binding/servicebinding=custom
+Annotations:  projection.service.binding/type: Custom
+API Version:  internal.service.binding/v1alpha2
+Kind:         ServiceBindingProjection
+Metadata:
+  Creation Timestamp:  2020-07-31T23:14:22Z
+  Generation:          1
+  Owner References:
+    API Version:           service.binding/v1alpha2
+    Block Owner Deletion:  true
+    Controller:            true
+    Kind:                  ServiceBinding
+    Name:                  custom
+    UID:                   07a4329b-6534-495b-99fa-13c36f8e95b7
+  Resource Version:        93219239
+  Self Link:               /apis/internal.service.binding/v1alpha2/namespaces/default/servicebindingprojections/custom
+  UID:                     80c14f83-969b-47d6-a487-11c62f1ead02
+Spec:
+  Application:
+    API Version:  v1
+    Kind:         Secret
+    Name:         custom
+  Binding:
+    Name:  custom-projection
+  Name:    custom
+Events:    <none>
+```
+
+The `ServiceBinding` resource will not become ready until the `ServiceBindingProjection` is successfully reconciled.
+
+## Play
+
+While too advanced for this sample, for those comfortable, try creating a controller to reconcile the `ServiceBindingProjection`.
+Make to only reconcile resources with the `projection.service.binding/type: Custom` annotation and an application reference that you know how to process.
+
+If that seems too complex, hopefully the ecosystem will evolve to provide turn-key custom projection reconcilers.
+For now, we'll have to wait.
+
+[custom-projections]: https://github.com/k8s-service-bindings/spec/#custom-projection
+[install]: ../../README.md#try-it-out

--- a/samples/custom-projection/service-binding.yaml
+++ b/samples/custom-projection/service-binding.yaml
@@ -1,0 +1,22 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: service.binding/v1alpha2
+kind: ServiceBinding
+metadata:
+  name: custom
+  annotations:
+    # disable the default binding projection
+    projection.service.binding/type: Custom
+spec:
+  # pointing application at a real resource, but not one we can reconcile as 
+  # PodSpecable, replace with the desired application.
+  application:
+    apiVersion: v1
+    kind: Secret
+    name: custom
+  service:
+    apiVersion: bindings.labs.vmware.com/v1alpha1
+    kind: ProvisionedService
+    name: custom

--- a/samples/custom-projection/service.yaml
+++ b/samples/custom-projection/service.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 VMware, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+---
+apiVersion: bindings.labs.vmware.com/v1alpha1
+kind: ProvisionedService
+metadata:
+  name: custom
+spec:
+  binding:
+    name: custom
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: custom
+type: Opaque
+stringData:
+  type: custom


### PR DESCRIPTION
Implements https://github.com/k8s-service-bindings/spec/tree/1.0.0-rc2#custom-projection

Resources wishing to opt-out of the default projection must set the projection type annotation on the ServiceBinding to `Custom`:

```yaml
....
metadata:
 ...
  annotations:
    projection.service.binding/type: Custom
```

Our `ServiceBinding` implementation will always create the
`ServiceBindingProjection`, even for non-custom projections for our own
internal use. Now we no longer reconcile the projection if the custom
projection annotation is set on the binding.
