### PR TITLE
Use apiextensions.k8s.io/v1 and admissionregistration.k8s.io/v1

### DIFF
--- a/config/300-provisionedservice.yaml
+++ b/config/300-provisionedservice.yaml
@@ -1,7 +1,7 @@
 # Copyright 2020 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: provisionedservices.bindings.labs.vmware.com
@@ -10,7 +10,6 @@ metadata:
     bindings.labs.vmware.com/crd-install: "true"
 spec:
   group: bindings.labs.vmware.com
-  version: v1alpha1
   names:
     kind: ProvisionedService
     listKind: ProvisionedServiceList
@@ -20,97 +19,101 @@ spec:
     - all
     - bind
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
-    name: Reason
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  validation:
-    openAPIV3Schema:
-      description: ProvisionedService exposes an existing Secret as a Service for binding
-        via a ServiceBinding
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ProvisionedServiceSpec defines the desired state of ProvisionedService
-          properties:
-            binding:
-              description: Binding exposes the secret for this service
-              properties:
-                name:
-                  description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-              required:
-              - name
-              type: object
-          required:
-          - binding
-          type: object
-        status:
-          description: ProvisionedServiceStatus defines the observed state of ProvisionedService
-          properties:
-            binding:
-              description: Binding exposes the secret for this service
-              properties:
-                name:
-                  description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-              required:
-              - name
-              type: object
-            conditions:
-              description: Conditions are the conditions of this ProvisionedService
-              items:
-                description: Condition contains details for the current condition of
-                  this ProvisionedService
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ProvisionedService exposes an existing Secret as a Service for binding
+          via a ServiceBinding
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ProvisionedServiceSpec defines the desired state of ProvisionedService
+            properties:
+              binding:
+                description: Binding exposes the secret for this service
                 properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human-readable message indicating details about last
-                      transition
-                    type: string
-                  reason:
-                    description: Unique, one-word, CamelCase reason for the condition's
-                      last transition
-                    type: string
-                  status:
-                    description: Status is the status of the condition Can be True,
-                      False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the condition
+                  name:
+                    description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
                 required:
-                - status
-                - type
+                - name
                 type: object
-              type: array
-            observedGeneration:
-              description: ObservedGeneration is the 'Generation' of the ProvisionedService
-                that was last processed by the controller.
-              format: int64
-              type: integer
-          type: object
-      type: object
+            required:
+            - binding
+            type: object
+          status:
+            description: ProvisionedServiceStatus defines the observed state of ProvisionedService
+            properties:
+              binding:
+                description: Binding exposes the secret for this service
+                properties:
+                  name:
+                    description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                required:
+                - name
+                type: object
+              conditions:
+                description: Conditions are the conditions of this ProvisionedService
+                items:
+                  description: Condition contains details for the current condition of
+                    this ProvisionedService
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about last
+                        transition
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition
+                      type: string
+                    status:
+                      description: Status is the status of the condition Can be True,
+                        False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the 'Generation' of the ProvisionedService
+                  that was last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/300-servicebinding.yaml
+++ b/config/300-servicebinding.yaml
@@ -1,17 +1,18 @@
 # Copyright 2020 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: servicebindings.service.binding
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
   labels:
     bindings.labs.vmware.com/release: devel
     bindings.labs.vmware.com/crd-install: "true"
     duck.knative.dev/binding: "true"
 spec:
   group: service.binding
-  version: v1alpha2
   names:
     kind: ServiceBinding
     listKind: ServiceBindingList
@@ -21,227 +22,231 @@ spec:
     - all
     - bind
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
-    name: Reason
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  validation:
-    openAPIV3Schema:
-      description: ServiceBinding is the Schema for the servicebindings API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceBindingSpec defines the desired state of ServiceBinding
-          properties:
-            application:
-              description: Application is a reference to an object that fulfills the
-                PodSpec duck type
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                containers:
-                  description: Containers describes which containers in a Pod should
-                    be bound to
-                  items:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
-                  type: array
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                selector:
-                  description: Selector is a query that selects the application or
-                    applications to bind the service to
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ServiceBinding is the Schema for the servicebindings API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceBindingSpec defines the desired state of ServiceBinding
+            properties:
+              application:
+                description: Application is a reference to an object that fulfills
+                  the PodSpec duck type
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  containers:
+                    description: Containers describes which containers in a Pod should
+                      be bound to
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  selector:
+                    description: Selector is a query that selects the application
+                      or applications to bind the service to
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
                               type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
                         type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
+                    type: object
+                required:
+                - apiVersion
+                - kind
+                type: object
+              env:
+                description: EnvVars is the collection of mappings from Secret entries
+                  to environment variables
+                items:
+                  description: ServiceBindingEnvVar defines a mapping from the value
+                    of a Secret entry to an environment variable
+                  properties:
+                    key:
+                      description: Key is the key in the Secret that will be exposed
+                      type: string
+                    name:
+                      description: Name is the name of the environment variable
+                      type: string
+                  required:
+                  - key
+                  - name
                   type: object
-              required:
-              - apiVersion
-              - kind
-              type: object
-            env:
-              description: EnvVars is the collection of mappings from Secret entries
-                to environment variables
-              items:
-                description: ServiceBindingEnvVar defines a mapping from the value
-                  of a Secret entry to an environment variable
+                type: array
+              mappings:
+                description: Mappings is the collection of mappings from existing
+                  Secret entries to new Secret entries
+                items:
+                  description: ServiceBindingMapping defines a mapping from the existing
+                    collection of Secret values to a new Secret entry.
+                  properties:
+                    name:
+                      description: Name is the name of the mapped Secret entry
+                      type: string
+                    value:
+                      description: Value is the value of the new Secret entry.  Contents
+                        may be a Go template and refer to the other secret entries
+                        by name.
+                      type: string
+                  required:
+                  - name
+                  - value
+                  type: object
+                type: array
+              name:
+                description: Name is the name of the service as projected into the
+                  application container.  Defaults to .metadata.name.
+                type: string
+              provider:
+                description: Provider is the provider of the service as projected
+                  into the application container
+                type: string
+              service:
+                description: Service is a reference to an object that fulfills the
+                  ProvisionedService duck type
                 properties:
-                  key:
-                    description: Key is the key in the Secret that will be exposed
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
-                    description: Name is the name of the environment variable
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
                 required:
-                - key
+                - apiVersion
+                - kind
                 - name
                 type: object
-              type: array
-            mappings:
-              description: Mappings is the collection of mappings from existing Secret
-                entries to new Secret entries
-              items:
-                description: ServiceBindingMapping defines a mapping from the existing
-                  collection of Secret values to a new Secret entry.
+              type:
+                description: Type is the type of the service as projected into the
+                  application container
+                type: string
+            required:
+            - application
+            - service
+            type: object
+          status:
+            description: ServiceBindingStatus defines the observed state of ServiceBinding
+            properties:
+              binding:
+                description: Binding exposes the projected secret for this ServiceBinding
                 properties:
                   name:
-                    description: Name is the name of the mapped Secret entry
-                    type: string
-                  value:
-                    description: Value is the value of the new Secret entry.  Contents
-                      may be a Go template and refer to the other secret entries by
-                      name.
+                    description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
                 required:
                 - name
-                - value
                 type: object
-              type: array
-            name:
-              description: Name is the name of the service as projected into the application
-                container.  Defaults to .metadata.name.
-              type: string
-            provider:
-              description: Provider is the provider of the service as projected into
-                the application container
-              type: string
-            service:
-              description: Service is a reference to an object that fulfills the ProvisionedService
-                duck type
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-              required:
-              - apiVersion
-              - kind
-              - name
-              type: object
-            type:
-              description: Type is the type of the service as projected into the application
-                container
-              type: string
-          required:
-          - application
-          - service
-          type: object
-        status:
-          description: ServiceBindingStatus defines the observed state of ServiceBinding
-          properties:
-            binding:
-              description: Binding exposes the projected secret for this ServiceBinding
-              properties:
-                name:
-                  description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-              required:
-              - name
-              type: object
-            conditions:
-              description: Conditions are the conditions of this ServiceBinding
-              items:
-                description: ServiceBindingCondition contains details for the current
-                  condition of this ServiceBinding
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human-readable message indicating details about last
-                      transition
-                    type: string
-                  reason:
-                    description: Unique, one-word, CamelCase reason for the condition's
-                      last transition
-                    type: string
-                  status:
-                    description: Status is the status of the condition Can be True,
-                      False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            observedGeneration:
-              description: ObservedGeneration is the 'Generation' of the ServiceBinding
-                that was last processed by the controller.
-              format: int64
-              type: integer
-          type: object
-      type: object
+              conditions:
+                description: Conditions are the conditions of this ServiceBinding
+                items:
+                  description: ServiceBindingCondition contains details for the current
+                    condition of this ServiceBinding
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition
+                      type: string
+                    status:
+                      description: Status is the status of the condition Can be True,
+                        False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the 'Generation' of the ServiceBinding
+                  that was last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/300-servicebindingprojection.yaml
+++ b/config/300-servicebindingprojection.yaml
@@ -1,17 +1,18 @@
 # Copyright 2020 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: servicebindingprojections.internal.service.binding
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
   labels:
     bindings.labs.vmware.com/release: devel
     bindings.labs.vmware.com/crd-install: "true"
     duck.knative.dev/binding: "true"
 spec:
   group: internal.service.binding
-  version: v1alpha2
   names:
     kind: ServiceBindingProjection
     listKind: ServiceBindingProjectionList
@@ -20,184 +21,189 @@ spec:
     categories:
     - bind
   scope: Namespaced
-  subresources:
-    status: {}
-  additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
-    name: Ready
-    type: string
-  - JSONPath: .status.conditions[?(@.type=="Ready")].reason
-    name: Reason
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
-  validation:
-    openAPIV3Schema:
-      description: ServiceBindingProjection is the Schema for the servicebindingprojections
-        API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ServiceBindingProjectionSpec defines the desired state of ServiceBindingProjection
-          properties:
-            application:
-              description: Application is a reference to an object that fulfills the
-                PodSpec duck type
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                containers:
-                  description: Containers describes which containers in a Pod should
-                    be bound to
-                  items:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    x-kubernetes-int-or-string: true
-                  type: array
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                selector:
-                  description: Selector is a query that selects the application or
-                    applications to bind the service to
-                  properties:
-                    matchExpressions:
-                      description: matchExpressions is a list of label selector requirements.
-                        The requirements are ANDed.
-                      items:
-                        description: A label selector requirement is a selector that
-                          contains values, a key, and an operator that relates the
-                          key and values.
-                        properties:
-                          key:
-                            description: key is the label key that the selector applies
-                              to.
-                            type: string
-                          operator:
-                            description: operator represents a key's relationship
-                              to a set of values. Valid operators are In, NotIn, Exists
-                              and DoesNotExist.
-                            type: string
-                          values:
-                            description: values is an array of string values. If the
-                              operator is In or NotIn, the values array must be non-empty.
-                              If the operator is Exists or DoesNotExist, the values
-                              array must be empty. This array is replaced during a
-                              strategic merge patch.
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - key
-                        - operator
-                        type: object
-                      type: array
-                    matchLabels:
-                      additionalProperties:
-                        type: string
-                      description: matchLabels is a map of {key,value} pairs. A single
-                        {key,value} in the matchLabels map is equivalent to an element
-                        of matchExpressions, whose key field is "key", the operator
-                        is "In", and the values array contains only "value". The requirements
-                        are ANDed.
-                      type: object
-                  type: object
-              required:
-              - apiVersion
-              - kind
-              type: object
-            binding:
-              description: Binding is the projected secret for this ServiceBindingProjection.
-              properties:
-                name:
-                  description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-              required:
-              - name
-              type: object
-            env:
-              description: EnvVars is the collection of mappings from Secret entries
-                to environment variables
-              items:
-                description: ServiceBindingProjectionEnvVar defines a mapping from
-                  the value of a Secret entry to an environment variable
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
+      name: Reason
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha2
+    schema:
+      openAPIV3Schema:
+        description: ServiceBindingProjection is the Schema for the servicebindingprojections
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ServiceBindingProjectionSpec defines the desired state of
+              ServiceBindingProjection
+            properties:
+              application:
+                description: Application is a reference to an object that fulfills
+                  the PodSpec duck type
                 properties:
-                  key:
-                    description: Key is the key in the Secret that will be exposed
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  containers:
+                    description: Containers describes which containers in a Pod should
+                      be bound to
+                    items:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      x-kubernetes-int-or-string: true
+                    type: array
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
                   name:
-                    description: Name is the name of the environment variable
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  selector:
+                    description: Selector is a query that selects the application
+                      or applications to bind the service to
+                    properties:
+                      matchExpressions:
+                        description: matchExpressions is a list of label selector
+                          requirements. The requirements are ANDed.
+                        items:
+                          description: A label selector requirement is a selector
+                            that contains values, a key, and an operator that relates
+                            the key and values.
+                          properties:
+                            key:
+                              description: key is the label key that the selector
+                                applies to.
+                              type: string
+                            operator:
+                              description: operator represents a key's relationship
+                                to a set of values. Valid operators are In, NotIn,
+                                Exists and DoesNotExist.
+                              type: string
+                            values:
+                              description: values is an array of string values. If
+                                the operator is In or NotIn, the values array must
+                                be non-empty. If the operator is Exists or DoesNotExist,
+                                the values array must be empty. This array is replaced
+                                during a strategic merge patch.
+                              items:
+                                type: string
+                              type: array
+                          required:
+                          - key
+                          - operator
+                          type: object
+                        type: array
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: matchLabels is a map of {key,value} pairs. A
+                          single {key,value} in the matchLabels map is equivalent
+                          to an element of matchExpressions, whose key field is "key",
+                          the operator is "In", and the values array contains only
+                          "value". The requirements are ANDed.
+                        type: object
+                    type: object
+                required:
+                - apiVersion
+                - kind
+                type: object
+              binding:
+                description: Binding is the projected secret for this ServiceBindingProjection.
+                properties:
+                  name:
+                    description: 'Name of the referent secret. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
                 required:
-                - key
                 - name
                 type: object
-              type: array
-            name:
-              description: Name is the name of the service as projected into the application
-                container.
-              type: string
-          required:
-          - application
-          - binding
-          - name
-          type: object
-        status:
-          description: ServiceBindingProjectionStatus defines the observed state of
-            ServiceBindingProjection
-          properties:
-            conditions:
-              description: Conditions are the conditions of this ServiceBindingProjection
-              items:
-                description: ServiceBindingProjectionCondition contains details for
-                  the current condition of this ServiceBindingProjection
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transitioned from one status
-                      to another
-                    format: date-time
-                    type: string
-                  message:
-                    description: Human-readable message indicating details about last
-                      transition
-                    type: string
-                  reason:
-                    description: Unique, one-word, CamelCase reason for the condition's
-                      last transition
-                    type: string
-                  status:
-                    description: Status is the status of the condition Can be True,
-                      False, Unknown.
-                    type: string
-                  type:
-                    description: Type is the type of the condition
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            observedGeneration:
-              description: ObservedGeneration is the 'Generation' of the ServiceBindingProjection
-                that was last processed by the controller.
-              format: int64
-              type: integer
-          type: object
-      type: object
+              env:
+                description: EnvVars is the collection of mappings from Secret entries
+                  to environment variables
+                items:
+                  description: ServiceBindingProjectionEnvVar defines a mapping from
+                    the value of a Secret entry to an environment variable
+                  properties:
+                    key:
+                      description: Key is the key in the Secret that will be exposed
+                      type: string
+                    name:
+                      description: Name is the name of the environment variable
+                      type: string
+                  required:
+                  - key
+                  - name
+                  type: object
+                type: array
+              name:
+                description: Name is the name of the service as projected into the
+                  application container.
+                type: string
+            required:
+            - application
+            - binding
+            - name
+            type: object
+          status:
+            description: ServiceBindingProjectionStatus defines the observed state
+              of ServiceBindingProjection
+            properties:
+              conditions:
+                description: Conditions are the conditions of this ServiceBindingProjection
+                items:
+                  description: ServiceBindingProjectionCondition contains details
+                    for the current condition of this ServiceBindingProjection
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: Human-readable message indicating details about
+                        last transition
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition
+                      type: string
+                    status:
+                      description: Status is the status of the condition Can be True,
+                        False, Unknown.
+                      type: string
+                    type:
+                      description: Type is the type of the condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                description: ObservedGeneration is the 'Generation' of the ServiceBindingProjection
+                  that was last processed by the controller.
+                format: int64
+                type: integer
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/400-webhook-configuration.yaml
+++ b/config/400-webhook-configuration.yaml
@@ -1,7 +1,7 @@
 # Copyright 2020 VMware, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: defaulting.webhook.bindings.labs.vmware.com
@@ -9,6 +9,7 @@ metadata:
     bindings.labs.vmware.com/release: devel
 webhooks:
 - admissionReviewVersions:
+  - v1
   - v1beta1
   clientConfig:
     service:
@@ -16,8 +17,9 @@ webhooks:
       namespace: service-bindings
   failurePolicy: Fail
   name: defaulting.webhook.bindings.labs.vmware.com
+  sideEffects: None
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validation.webhook.bindings.labs.vmware.com
@@ -25,6 +27,7 @@ metadata:
     bindings.labs.vmware.com/release: devel
 webhooks:
 - admissionReviewVersions:
+  - v1
   - v1beta1
   clientConfig:
     service:
@@ -32,8 +35,9 @@ webhooks:
       namespace: service-bindings
   failurePolicy: Fail
   name: validation.webhook.bindings.labs.vmware.com
+  sideEffects: None
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: config.webhook.bindings.labs.vmware.com
@@ -41,6 +45,7 @@ metadata:
     bindings.labs.vmware.com/release: devel
 webhooks:
 - admissionReviewVersions:
+  - v1
   - v1beta1
   clientConfig:
     service:
@@ -52,8 +57,9 @@ webhooks:
     matchExpressions:
     - key: bindings.labs.vmware.com/release
       operator: Exists
+  sideEffects: None
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: servicebindingprojections.webhook.bindings.labs.vmware.com
@@ -61,6 +67,7 @@ metadata:
     bindings.labs.vmware.com/release: devel
 webhooks:
 - admissionReviewVersions:
+  - v1
   - v1beta1
   clientConfig:
     service:
@@ -68,6 +75,7 @@ webhooks:
       namespace: service-bindings
   failurePolicy: Fail
   name: servicebindingprojections.webhook.bindings.labs.vmware.com
+  sideEffects: None
 ---
 apiVersion: v1
 kind: Secret

--- a/config/kapp/config-kapp.yaml
+++ b/config/kapp/config-kapp.yaml
@@ -30,5 +30,5 @@ rebaseRules:
   type: copy
   sources: [existing]
   resourceMatchers:
-  - apiVersionKindMatcher: {apiVersion: admissionregistration.k8s.io/v1beta1, kind: MutatingWebhookConfiguration}
-  - apiVersionKindMatcher: {apiVersion: admissionregistration.k8s.io/v1beta1, kind: ValidatingWebhookConfiguration}
+  - apiVersionKindMatcher: {apiVersion: admissionregistration.k8s.io/v1, kind: MutatingWebhookConfiguration}
+  - apiVersionKindMatcher: {apiVersion: admissionregistration.k8s.io/v1, kind: ValidatingWebhookConfiguration}


### PR DESCRIPTION
These api version are supported and the v1beta1 version is deprecated as
of k8s 1.16.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>