### PR TITLE
SERVICE_BINDINGS_ROOT -> SERVICE_BINDING_ROOT

### DIFF
--- a/pkg/apis/servicebindinginternal/v1alpha2/servicebindingprojection_lifecycle.go
+++ b/pkg/apis/servicebindinginternal/v1alpha2/servicebindingprojection_lifecycle.go
@@ -23,6 +23,8 @@ import (
 const (
 	ServiceBindingProjectionConditionReady                = apis.ConditionReady
 	ServiceBindingProjectionConditionApplicationAvailable = "ApplicationAvailable"
+
+	ServiceBindingRootEnv = "SERVICE_BINDING_ROOT"
 )
 
 var sbpCondSet = apis.NewLivingConditionSet(
@@ -108,7 +110,7 @@ func (b *ServiceBindingProjection) doContainer(ctx context.Context, ps *duckv1.W
 	mountPath := ""
 	// lookup predefined mount path
 	for _, e := range c.Env {
-		if e.Name == "SERVICE_BINDINGS_ROOT" {
+		if e.Name == ServiceBindingRootEnv {
 			mountPath = e.Value
 			break
 		}
@@ -117,7 +119,7 @@ func (b *ServiceBindingProjection) doContainer(ctx context.Context, ps *duckv1.W
 		// default mount path
 		mountPath = "/bindings"
 		c.Env = append(c.Env, corev1.EnvVar{
-			Name:  "SERVICE_BINDINGS_ROOT",
+			Name:  ServiceBindingRootEnv,
 			Value: mountPath,
 		})
 	}

--- a/pkg/apis/servicebindinginternal/v1alpha2/servicebindingprojection_lifecycle.go
+++ b/pkg/apis/servicebindinginternal/v1alpha2/servicebindingprojection_lifecycle.go
@@ -25,6 +25,9 @@ const (
 	ServiceBindingProjectionConditionApplicationAvailable = "ApplicationAvailable"
 
 	ServiceBindingRootEnv = "SERVICE_BINDING_ROOT"
+	// Deprecated: favor ServiceBindingRootEnv, this value will be removed in a
+	// future release
+	DeprecatedServiceBindingsRootEnv = "SERVICE_BINDINGS_ROOT"
 )
 
 var sbpCondSet = apis.NewLivingConditionSet(
@@ -108,21 +111,29 @@ func (b *ServiceBindingProjection) Do(ctx context.Context, ps *duckv1.WithPod) {
 
 func (b *ServiceBindingProjection) doContainer(ctx context.Context, ps *duckv1.WithPod, c *corev1.Container, bindingVolume, secretName string) {
 	mountPath := ""
+	env := []corev1.EnvVar{}
 	// lookup predefined mount path
 	for _, e := range c.Env {
-		if e.Name == ServiceBindingRootEnv {
+		if e.Name == ServiceBindingRootEnv || e.Name == DeprecatedServiceBindingsRootEnv {
 			mountPath = e.Value
-			break
+		} else {
+			env = append(env, e)
 		}
 	}
 	if mountPath == "" {
 		// default mount path
 		mountPath = "/bindings"
-		c.Env = append(c.Env, corev1.EnvVar{
+	}
+	c.Env = append(env,
+		corev1.EnvVar{
 			Name:  ServiceBindingRootEnv,
 			Value: mountPath,
-		})
-	}
+		},
+		corev1.EnvVar{
+			Name:  DeprecatedServiceBindingsRootEnv,
+			Value: mountPath,
+		},
+	)
 
 	containerVolumes := sets.NewString()
 	for _, vm := range c.VolumeMounts {

--- a/pkg/apis/servicebindinginternal/v1alpha2/servicebindingprojection_test.go
+++ b/pkg/apis/servicebindinginternal/v1alpha2/servicebindingprojection_test.go
@@ -782,6 +782,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
+											Value: "/bindings",
+										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -797,6 +801,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 									Env: []corev1.EnvVar{
 										{
 											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -876,6 +884,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
+											Value: "/bindings",
+										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -893,6 +905,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 									Env: []corev1.EnvVar{
 										{
 											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -975,6 +991,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
+											Value: "/bindings",
+										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -1045,6 +1065,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 									Env: []corev1.EnvVar{
 										{
 											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -1119,6 +1143,86 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 									Env: []corev1.EnvVar{
 										{
 											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/custom/path",
+										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
+											Value: "/custom/path",
+										},
+									},
+									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "binding-5c5a15a8b0b3e154d77746945e563ba40100681b",
+											MountPath: "/custom/path/my-binding-name",
+											ReadOnly:  true,
+										},
+									},
+								},
+							},
+							Volumes: []corev1.Volume{
+								{
+									Name: "binding-5c5a15a8b0b3e154d77746945e563ba40100681b",
+									VolumeSource: corev1.VolumeSource{
+										Secret: &corev1.SecretVolumeSource{
+											SecretName: "my-secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "inject volume at custom path, deprecated var",
+			binding: &ServiceBindingProjection{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-binding",
+				},
+				Spec: ServiceBindingProjectionSpec{
+					Name: "my-binding-name",
+					Binding: corev1.LocalObjectReference{
+						Name: "my-secret",
+					},
+				},
+			},
+			seed: &duckv1.WithPod{
+				Spec: duckv1.WithPodSpec{
+					Template: duckv1.PodSpecable{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
+											Value: "/custom/path",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: &duckv1.WithPod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"internal.service.binding/projection-16384e6a11df69776193b6a877b": "binding-5c5a15a8b0b3e154d77746945e563ba40100681b",
+					},
+				},
+				Spec: duckv1.WithPodSpec{
+					Template: duckv1.PodSpecable{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Env: []corev1.EnvVar{
+										{
+											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/custom/path",
+										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
 											Value: "/custom/path",
 										},
 									},
@@ -1199,6 +1303,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 										},
 										{
 											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
 											Value: "/bindings",
 										},
 										{
@@ -1338,6 +1446,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
+											Value: "/bindings",
+										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -1378,6 +1490,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
+											Value: "/bindings",
+										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
 										{
@@ -1393,6 +1509,10 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 									Env: []corev1.EnvVar{
 										{
 											Name:  "SERVICE_BINDING_ROOT",
+											Value: "/bindings",
+										},
+										{
+											Name:  "SERVICE_BINDINGS_ROOT",
 											Value: "/bindings",
 										},
 									},

--- a/pkg/apis/servicebindinginternal/v1alpha2/servicebindingprojection_test.go
+++ b/pkg/apis/servicebindinginternal/v1alpha2/servicebindingprojection_test.go
@@ -779,7 +779,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -796,7 +796,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -873,7 +873,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 									Name: "my-container",
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -892,7 +892,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 									Name: "my-container",
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -972,7 +972,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -1044,7 +1044,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -1095,7 +1095,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/custom/path",
 										},
 									},
@@ -1118,7 +1118,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/custom/path",
 										},
 									},
@@ -1198,7 +1198,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 											Name: "PRESERVE",
 										},
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 										{
@@ -1318,7 +1318,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -1335,7 +1335,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -1375,7 +1375,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},
@@ -1392,7 +1392,7 @@ func TestServiceBindingProjection_Do(t *testing.T) {
 								{
 									Env: []corev1.EnvVar{
 										{
-											Name:  "SERVICE_BINDINGS_ROOT",
+											Name:  "SERVICE_BINDING_ROOT",
 											Value: "/bindings",
 										},
 									},

--- a/samples/controlled-resource/README.md
+++ b/samples/controlled-resource/README.md
@@ -38,7 +38,7 @@ It will contain an environment variable `TARGET` provided by the binding.
 ```
 ...
         Env:
-          Name:   SERVICE_BINDINGS_ROOT
+          Name:   SERVICE_BINDING_ROOT
           Value:  /bindings
           Name:   TARGET
           Value From:

--- a/samples/spring-petclinic/README.md
+++ b/samples/spring-petclinic/README.md
@@ -28,7 +28,7 @@ Inspect the PetClinic application as bound:
 kubectl describe deployment spring-petclinic
 ```
 
-If the ServiceBinding is working, a new environment variable (SERVICE_BINDINGS_ROOT), volume and volume mount (binding-49a23274b0590d5057aae1ae621be723716c4dd5) is added to the deployment.
+If the ServiceBinding is working, a new environment variable (SERVICE_BINDING_ROOT), volume and volume mount (binding-49a23274b0590d5057aae1ae621be723716c4dd5) is added to the deployment.
 The describe output will contain:
 
 ```txt
@@ -40,7 +40,7 @@ The describe output will contain:
     Host Port:  <none>
     Environment:
       SPRING_PROFILES_ACTIVE:  mysql
-      SERVICE_BINDINGS_ROOT:   /bindings
+      SERVICE_BINDING_ROOT:    /bindings
     Mounts:
       /bindings/spring-petclinic-db from binding-49a23274b0590d5057aae1ae621be723716c4dd5 (ro)
   Volumes:


### PR DESCRIPTION
The spec used both names, normalizing to the singular.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>