### PR TITLE
Add 'knative.dev' to include/exclude labels

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cSpell.enabled": true
+}

--- a/cmd/labs-service-bindings-manager/main.go
+++ b/cmd/labs-service-bindings-manager/main.go
@@ -37,10 +37,13 @@ import (
 )
 
 var (
+	// TODO(scothis) restore labels after https://github.com/vmware-labs/service-bindings/issues/130
 	//BindingExcludeLabel can be applied to exclude resource from webhook
-	BindingExcludeLabel = "bindings.labs.vmware.com/exclude"
+	// BindingExcludeLabel = "bindings.labs.vmware.com/exclude"
+	BindingExcludeLabel = "knative.dev.bindings.labs.vmware.com/exclude"
 	//BindingIncludeLabel can be applied to include resource in webhook
-	BindingIncludeLabel = "bindings.labs.vmware.com/include"
+	// BindingIncludeLabel = "bindings.labs.vmware.com/include"
+	BindingIncludeLabel = "knative.dev.bindings.labs.vmware.com/include"
 
 	ExclusionSelector = metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{{

--- a/config/100-namespace.yaml
+++ b/config/100-namespace.yaml
@@ -7,4 +7,4 @@ metadata:
   name: service-bindings
   labels:
     bindings.labs.vmware.com/release: devel
-    bindings.labs.vmware.com/exclude: "true"
+    knative.dev.bindings.labs.vmware.com/exclude: "true"

--- a/config/manager.yaml
+++ b/config/manager.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: service-bindings
   labels:
     bindings.labs.vmware.com/release: devel
-    bindings.labs.vmware.com/exclude: "true"
+    knative.dev.bindings.labs.vmware.com/exclude: "true"
 spec:
   replicas: 1
   selector:
@@ -23,7 +23,7 @@ spec:
         app: manager
         role: manager
         bindings.labs.vmware.com/release: devel
-        bindings.labs.vmware.com/exclude: "true"
+        knative.dev.bindings.labs.vmware.com/exclude: "true"
     spec:
       serviceAccountName: controller
       containers:


### PR DESCRIPTION
Workaround for an upstream knative issue that cause corruption within
the mutating webhook configuration for intercepting bound applications.

Refs #130

Signed-off-by: Scott Andrews <andrewssc@vmware.com>