### PR TITLE
Ignore major (semver minor) k8s.io updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: k8s.io/*
+    update-types:
+    - version-update:semver-major
+    - version-update:semver-minor


### PR DESCRIPTION
Non-patch Kubernetes releases need to be cordinated with the upstream
Knative libraries. We should ignore them to avoid accidental merges of
Dependabot PRs.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>