### PR TITLE
Iniitialize status conditions

### DIFF
--- a/pkg/apis/servicebinding/v1alpha3/servicebinding_lifecycle.go
+++ b/pkg/apis/servicebinding/v1alpha3/servicebinding_lifecycle.go
@@ -19,12 +19,13 @@ const (
 	ServiceBindingConditionReady            = "Ready"
 	ServiceBindingConditionServiceAvailable = "ServiceAvailable"
 	ServiceBindingConditionProjectionReady  = "ProjectionReady"
+	InitializeConditionReason               = "Unknown"
 )
 
-func (bs *ServiceBindingStatus) InitializeConditions() {
-	ready := metav1.Condition{Type: ServiceBindingConditionReady}
-	serviceAvailable := metav1.Condition{Type: ServiceBindingConditionServiceAvailable}
-	projectionReady := metav1.Condition{Type: ServiceBindingConditionProjectionReady}
+func (bs *ServiceBindingStatus) InitializeConditions(now metav1.Time) {
+	ready := metav1.Condition{Type: ServiceBindingConditionReady, Status: metav1.ConditionUnknown, LastTransitionTime: now, Reason: InitializeConditionReason}
+	serviceAvailable := metav1.Condition{Type: ServiceBindingConditionServiceAvailable, Status: metav1.ConditionUnknown, LastTransitionTime: now, Reason: InitializeConditionReason}
+	projectionReady := metav1.Condition{Type: ServiceBindingConditionProjectionReady, Status: metav1.ConditionUnknown, LastTransitionTime: now, Reason: InitializeConditionReason}
 	for _, c := range bs.Conditions {
 		switch c.Type {
 		case ServiceBindingConditionReady:

--- a/pkg/apis/servicebinding/v1alpha3/servicebinding_lifecycle.go
+++ b/pkg/apis/servicebinding/v1alpha3/servicebinding_lifecycle.go
@@ -113,10 +113,6 @@ func (bs *ServiceBindingStatus) aggregateReadyCondition(now metav1.Time) {
 		bs.Conditions[0].Status = metav1.ConditionUnknown
 		bs.Conditions[0].Reason = fmt.Sprintf("%s%s", ServiceBindingConditionProjectionReady, bs.Conditions[2].Reason)
 		bs.Conditions[0].Message = bs.Conditions[2].Message
-	} else {
-		bs.Conditions[0].Status = metav1.ConditionUnknown
-		bs.Conditions[0].Reason = "Unknown"
-		bs.Conditions[0].Message = ""
 	}
 
 	// update time when the status changes

--- a/pkg/reconciler/servicebinding/servicebinding.go
+++ b/pkg/reconciler/servicebinding/servicebinding.go
@@ -58,8 +58,8 @@ func (r *Reconciler) ReconcileKind(ctx context.Context, binding *servicebindingv
 		return nil
 	}
 
-	binding.Status.InitializeConditions()
 	now := r.now()
+	binding.Status.InitializeConditions(now)
 
 	secretRef, err := r.provisionedSecret(ctx, logger, binding)
 	if err != nil {


### PR DESCRIPTION

Pull request

### What this PR does / why we need it
K8s API server is rejecting status condition with no values. So update initialize conditions func to initialize all fields in status resource.

### Which issue(s) this PR fixes
Fixes #177 

### Describe testing done for PR
Use the testcase from #177 issue. 

### Additional information or special notes for your reviewer
