### PR TITLE
downgrade imgpkg to v0.22.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,13 @@ jobs:
       with:
         go-version: 1.15.x
     - uses: vmware-tanzu/carvel-setup-action@v1
+      with:
+        imgpkg: v0.22.0
+    - run: |
+        imgpkg version
+        kbld version
+        ytt version
+
     - name: Install ko
       run: |
         cd $(mktemp -d -t ko.XXXX)
@@ -115,6 +122,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: vmware-tanzu/carvel-setup-action@v1
+      with:
+        imgpkg: v0.22.0
+    - run: |
+        imgpkg version
+        kbld version
+        ytt version
+
     - name: Install kind
       run: |
         cd $(mktemp -d -t kind.XXXX)
@@ -278,6 +292,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2.4.0
     - uses: vmware-tanzu/carvel-setup-action@v1
+      with:
+        imgpkg: v0.22.0
+    - run: |
+        imgpkg version
+        kbld version
+        ytt version
+        
     - name: Install crane
       run: |
         cd $(mktemp -d -t kind.XXXX)


### PR DESCRIPTION
Signed-off-by: Rashed Kamal <krashed@vmware.com>

Pull request
<!-- Please use this template and provide as much info as possible. Not doing so may delay the review of the pull request. Thanks!
-->
Issue found with `imgpkg v0.23.0` 
### What this PR does / why we need it

This PR downgrades to `imgpkg` GHA plugin to `v0.22.0`. 

### Which issue(s) this PR fixes
<!--
     Unless the PR is for a trivial change (e.g. fixing a typo), consider opening an issue first (and reference it here) so that the problem the PR addresses can be discussed independently of the solutions proposed by this PR. Usage: Fixes #<issue number>.
-->

Fixes #197 

### Describe testing done for PR

<!-- Example: Created vSphere workload cluster to verify change. -->


### Additional information or special notes for your reviewer

<!-- Add notes to that can aid in the review process, or leave blank -->
<detail>
copy | importing 2 images...
copy | done uploading images
imgpkg: Error: Updating Image Refs registry.local:5000/service-bindings/bundle@sha256:8db097671917f25f32d5a7afe54f95a0c112728e024c9f80524d45b11438ea82:
  Fetching images of registry.local:5000/service-bindings/bundle@sha256:8db097671917f25f32d5a7afe54f95a0c112728e024c9f80524d45b11438ea82:
  Fetching location image:
      Get "https://registry.local:5000/v2/": dial tcp: lookup registry.local on 127.0.0.53:53: server misbehaving; Get "http://registry.local:5000/v2/": dial tcp: lookup registry.local on 127.0.0.53:53: server misbehaving
Error: Process completed with exit code 1.
</detail>
<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->

