### PR TITLE
Test for clean redeploys with kapp

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,8 +39,6 @@ jobs:
       with:
         go-version: 1.15.x
     - uses: vmware-tanzu/carvel-setup-action@v1
-      with:
-        imgpkg: v0.22.0
     - run: |
         imgpkg version
         kbld version
@@ -219,6 +217,7 @@ jobs:
             ytt -f config/carvel/package-install.yaml -f config/carvel/package-install.values.yaml \
               --data-value package_constraints=$(cat VERSION) \
               --data-value-yaml 'package_prerelease={}' \
+              --data-value sync_period=1m \
           )
     - name: Deploy Spring Petclinic
       run: |
@@ -231,6 +230,8 @@ jobs:
         kapp deploy -a spring-petclinic -f samples/spring-petclinic/workload.yaml -y
     - name: Collect diagnostics
       run: |
+        set +o errexit
+
         echo "##[group]Describe nodes"
           kubectl describe nodes
         echo "##[endgroup]"
@@ -245,6 +246,12 @@ jobs:
         echo "##[endgroup]"
         echo "##[group]Package Installs"
           kubectl get packageinstall -A -oyaml
+        echo "##[endgroup]"
+        echo "##[group]Kapp list apps"
+          kapp list -A
+        echo "##[endgroup]"
+        echo "##[group]Package changesets"
+          kapp app-change list -a service-bindings-ctrl
         echo "##[endgroup]"
         echo "##[group]Service Binding manager logs"
           kubectl logs -n service-bindings -l app=manager -c manager --tail 1000
@@ -263,6 +270,20 @@ jobs:
         echo "##[endgroup]"
       if: always()
       continue-on-error: true
+    - name: Fail for multiple kapp changes
+      run: |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        # I hate to slow down CI, but the current tests run in about a minute, which may not be long enough to see a redeploy
+        sleep 60
+
+        deploys=$(kapp app-change list -a service-bindings-ctrl --json | jq '.Tables[0].Rows | length')
+        if [ "$deploys" != "1" ]; then
+          echo "Too many app changes for the service-binding package, expected 1 found ${deploys}"
+          exit 1
+        fi
     - name: Cleanup Spring Petclinic
       run: |
         set -o errexit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -217,7 +217,7 @@ jobs:
             ytt -f config/carvel/package-install.yaml -f config/carvel/package-install.values.yaml \
               --data-value package_constraints=$(cat VERSION) \
               --data-value-yaml 'package_prerelease={}' \
-              --data-value sync_period=1m \
+              --data-value sync_period=10s \
           )
     - name: Deploy Spring Petclinic
       run: |
@@ -275,9 +275,6 @@ jobs:
         set -o errexit
         set -o nounset
         set -o pipefail
-
-        # I hate to slow down CI, but the current tests run in about a minute, which may not be long enough to see a redeploy
-        sleep 60
 
         deploys=$(kapp app-change list -a service-bindings-ctrl --json | jq '.Tables[0].Rows | length')
         if [ "$deploys" != "1" ]; then

--- a/config/200-clusterrole.yaml
+++ b/config/200-clusterrole.yaml
@@ -14,7 +14,7 @@ aggregationRule:
   # legacy support
   - matchLabels:
       service.binding/controller: "true"
-rules: [] # Rules are automatically filled in by the controller manager.
+# rules are automatically filled in at runtime.
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/config/400-webhook-configuration.yaml
+++ b/config/400-webhook-configuration.yaml
@@ -84,4 +84,4 @@ metadata:
   namespace: service-bindings
   labels:
     bindings.labs.vmware.com/release: devel
-# The data is populated at install time.
+# data is populated at runtime.

--- a/config/carvel/package-install.values.yaml
+++ b/config/carvel/package-install.values.yaml
@@ -12,3 +12,4 @@ package_prerelease: null
 service_account_name: service-binding-kc
 cluster_role_name: service-binding-kc
 cluster_role_binding_name: service-binding-kc
+sync_period: 10m

--- a/config/carvel/package-install.yaml
+++ b/config/carvel/package-install.yaml
@@ -14,6 +14,7 @@ metadata:
     kapp.k14s.io/change-rule: "upsert after upserting service-bindings.labs.vmware.com/install-rbac"
 spec:
   serviceAccountName: #@ data.values.service_account_name
+  syncPeriod: #@ data.values.sync_period
   packageRef:
     refName: #@ data.values.package_name
     versionSelection:

--- a/config/config-kapp.yaml
+++ b/config/config-kapp.yaml
@@ -19,14 +19,19 @@ data:
       type: copy
       sources: [existing]
       resourceMatchers:
-      - kindNamespaceNameMatcher: {kind: ClusterRole, namespace: "", name: service-binding-admin}
+      - andMatcher:
+          matchers:
+          - apiVersionKindMatcher: {apiVersion: rbac.authorization.k8s.io/v1, kind: ClusterRole}
+          - kindNamespaceNameMatcher: {kind: ClusterRole, name: service-binding-admin}
     - path: [data]
       type: copy
       sources: [existing]
       resourceMatchers:
-      - kindNamespaceNameMatcher: {kind: Secret, namespace: service-bindings, name: webhook-certs}
+      - andMatcher:
+          matchers:
+          - apiVersionKindMatcher: {apiVersion: v1, kind: Secret}
+          - kindNamespaceNameMatcher: {kind: Secret, namespace: service-bindings, name: webhook-certs}
     - paths:
-      - [metadata, annotations]
       - [webhooks, {allIndexes: true}, clientConfig, caBundle]
       - [webhooks, {allIndexes: true}, clientConfig, service, path]
       - [webhooks, {allIndexes: true}, clientConfig, service, port]


### PR DESCRIPTION
A kapp deploy will attempt to make the resources on the api server match
the resources defined locally. Because the manager will modify the
resources we create at runtime, we should respect those mutations and
avoid overwriting them. This is typically done with rebase rules in the
kapp config resource.

During the acceptance tests, we set the kapp-controller sync period for
the package to 1 minute. If we see multiple changeset, the config is not
stable.

Signed-off-by: Scott Andrews <andrewssc@vmware.com>
