### PR TITLE
Fix Webhook failures in k8s 1.22+

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,7 @@ jobs:
         - 1.18.15
         - 1.19.7
         - 1.20.2
+        - 1.22.6
       fail-fast: false
     env:
       REGISTRY_NAME: registry.local

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	k8s.io/apimachinery v0.19.16
 	k8s.io/client-go v0.19.16
 	k8s.io/code-generator v0.19.16
-	knative.dev/pkg v0.0.0-20210331065221-952fdd90dbb0 // pin to branch release-0.22
+	knative.dev/pkg v0.0.0-20210902173607-983897f9e37f // pin to branch release-0.22
 )

--- a/go.sum
+++ b/go.sum
@@ -1093,6 +1093,8 @@ knative.dev/hack v0.0.0-20210325223819-b6ab329907d3 h1:km0Rrh0T9/wA2pivQm1hqSPVw
 knative.dev/hack v0.0.0-20210325223819-b6ab329907d3/go.mod h1:PHt8x8yX5Z9pPquBEfIj0X66f8iWkWfR0S/sarACJrI=
 knative.dev/pkg v0.0.0-20210331065221-952fdd90dbb0 h1:z05hcB4br0qz7JdwIoUSTXLTF+7ThuJ+R6NFfXd1Y4Q=
 knative.dev/pkg v0.0.0-20210331065221-952fdd90dbb0/go.mod h1:PD5g8hUCXq6iR3tILjmZeJBvQfXGnHMPKryq54qHJhg=
+knative.dev/pkg v0.0.0-20210902173607-983897f9e37f h1:5XjG0xQQYN/Bw+7vUhLENcDOBQPCVns6v3vJcJ1SXZM=
+knative.dev/pkg v0.0.0-20210902173607-983897f9e37f/go.mod h1:PD5g8hUCXq6iR3tILjmZeJBvQfXGnHMPKryq54qHJhg=
 pgregory.net/rapid v0.3.3/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=


### PR DESCRIPTION
### What this PR does / why we need it

Kubernetes 1.22 added a new subresource field https://github.com/kubernetes/kubernetes/pull/100970. The knative pkg which is used the webhook had an issue that was resolved here https://github.com/knative/serving/issues/11448.

This change bumps the knative pkg dependency which includes the fix but keeps it pinned on the 0.22 release branch.

In addition it adds 1.22.6 to the k8s testing matrix in Github actions.

fixes #214

### Describe testing done for PR

1. Created k8s 1.22/1.23 on Kind
1. `ko apply -f config/` with this change.
1. `k apply -f samples/spring-pet-clinic`
1. Verified the binding is successful.

## Note

This bumps the knative pkg only two commits https://github.com/knative/pkg/commits/release-0.22 so *should* be a relatively low risk change. 
