### PR TITLE
Add test to CI that verifies Binding readiness

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -282,6 +282,19 @@ jobs:
         echo "##[endgroup]"
       if: always()
       continue-on-error: true
+    - name: Fail if Service Binding is not Ready
+      run: |
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+        ready=$(kubectl get -f samples/spring-petclinic/service-binding.yaml -o jsonpath='{.status.conditions[?(@.type == "Ready")].status'})
+        if [ "$ready" != "True" ]; then
+          echo "Expected Service Binding Ready status to be True, found ${ready}"
+          echo "##[group]Service Binding Resource"
+            kubectl get -f samples/spring-petclinic/service-binding.yaml -o yaml
+          echo "##[endgroup]"
+          exit 1
+        fi
     - name: Fail for multiple kapp changes
       run: |
         set -o errexit


### PR DESCRIPTION
### What this PR does / why we need it

This adds validation that Service Binding becomes Ready in CI. This was used as part of testing in #217 for the issue #214.
 


